### PR TITLE
remove jumping when moving image before text

### DIFF
--- a/src/js/plugins/scribe-plugin-inline-objects.js
+++ b/src/js/plugins/scribe-plugin-inline-objects.js
@@ -224,8 +224,6 @@ define([],function () {
 
                 setTimeout(function() {
                   showToolbar();
-                  var newTop = $(activeElement).offset().top;
-                  window.scrollBy(0, newTop - top);
                 }, 0);
               });
             }


### PR DESCRIPTION
this is causing an issue for multi-entry articles, where moving an image up will cause the editor jump of the top of the page.